### PR TITLE
Add live service status panel to frontend dashboard

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -278,6 +278,170 @@
   color: var(--text-muted);
 }
 
+/* ── Status panel ────────────────────────────────── */
+
+.status-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.status-panel__loading {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.status-panel__overall {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.65rem;
+  border-radius: 5px;
+  margin-bottom: 0.25rem;
+}
+
+.status-panel__overall--healthy {
+  background: var(--ok-bg);
+}
+
+.status-panel__overall--degraded {
+  background: var(--warn-bg);
+}
+
+.status-panel__overall--unhealthy {
+  background: var(--danger-bg);
+}
+
+.status-panel__overall-dot {
+  width: 8px;
+  height: 8px;
+  flex-shrink: 0;
+  border-radius: 50%;
+}
+
+.status-panel__overall--healthy .status-panel__overall-dot {
+  background: var(--ok);
+  box-shadow: 0 0 8px var(--ok);
+}
+
+.status-panel__overall--degraded .status-panel__overall-dot {
+  background: var(--warn);
+  box-shadow: 0 0 8px var(--warn);
+}
+
+.status-panel__overall--unhealthy .status-panel__overall-dot {
+  background: var(--danger);
+  box-shadow: 0 0 8px var(--danger);
+}
+
+.status-panel__overall-label {
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--pacific-slate);
+}
+
+.status-check {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.55rem;
+  padding: 0.55rem 0.65rem;
+  border-radius: 5px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface-raised);
+}
+
+.status-check__dot {
+  width: 7px;
+  height: 7px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  margin-top: 0.25rem;
+}
+
+.status-check--ok .status-check__dot {
+  background: var(--ok);
+  box-shadow: 0 0 6px var(--ok);
+}
+
+.status-check--error .status-check__dot {
+  background: var(--danger);
+  box-shadow: 0 0 6px var(--danger);
+}
+
+.status-check--not_configured .status-check__dot {
+  background: var(--warn);
+  box-shadow: 0 0 6px var(--warn);
+}
+
+.status-check--skipped .status-check__dot {
+  background: var(--text-dim);
+}
+
+.status-check__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.status-check__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.status-check__name {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--pacific-slate);
+}
+
+.status-check__badge {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  font-weight: 500;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.status-check--ok .status-check__badge {
+  color: var(--ok);
+  background: var(--ok-bg);
+}
+
+.status-check--error .status-check__badge {
+  color: var(--danger);
+  background: var(--danger-bg);
+}
+
+.status-check--not_configured .status-check__badge {
+  color: var(--warn);
+  background: var(--warn-bg);
+}
+
+.status-check--skipped .status-check__badge {
+  color: var(--text-dim);
+  background: rgba(92, 114, 138, 0.15);
+}
+
+.status-check__latency {
+  font-family: var(--font-mono);
+  font-size: 0.65rem;
+  color: var(--text-muted);
+}
+
+.status-check__msg {
+  font-size: 0.7rem;
+  color: var(--text-dim);
+  line-height: 1.35;
+  word-break: break-word;
+}
+
 .map-skeleton {
   position: absolute;
   inset: 0;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@
  */
 import { lazy, Suspense, useCallback, useEffect, useState } from 'react'
 import type { InsightLayerState } from './components/VancouverMap'
+import StatusPanel from './components/StatusPanel'
 import './App.css'
 
 const VancouverMap = lazy(() => import('./components/VancouverMap'))
@@ -91,6 +92,12 @@ export default function App() {
         </main>
 
         <aside className="insight-shell__rail insight-shell__rail--right" aria-label="Signals">
+          <section className="insight-panel">
+            <h2 className="insight-panel__heading">Service status</h2>
+            <p className="insight-panel__hint">Live health from /api/health/ — polled every 30 s.</p>
+            <StatusPanel />
+          </section>
+
           <section className="insight-panel">
             <h2 className="insight-panel__heading">City signals</h2>
             <p className="insight-panel__hint">Placeholder tiles until API feeds land.</p>

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -1,0 +1,117 @@
+import { useEffect, useState, useCallback } from 'react'
+
+interface ServiceCheck {
+  status: 'ok' | 'error' | 'not_configured' | 'skipped'
+  message: string
+  latency_ms?: number
+  base_url?: string
+  url?: string
+}
+
+interface HealthResponse {
+  status: 'healthy' | 'degraded' | 'unhealthy'
+  service: string
+  checks: Record<string, ServiceCheck>
+}
+
+const STATUS_LABEL: Record<string, string> = {
+  ok: 'Operational',
+  error: 'Error',
+  not_configured: 'Not configured',
+  skipped: 'Skipped',
+}
+
+const POLL_INTERVAL_MS = 30_000
+
+export default function StatusPanel() {
+  const [health, setHealth] = useState<HealthResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  const fetchHealth = useCallback(async () => {
+    try {
+      const res = await fetch('/api/health/')
+      if (!res.ok && res.status !== 503) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+      const data: HealthResponse = await res.json()
+      setHealth(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reach API')
+      setHealth(null)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchHealth()
+    const id = window.setInterval(fetchHealth, POLL_INTERVAL_MS)
+    return () => window.clearInterval(id)
+  }, [fetchHealth])
+
+  if (loading) {
+    return (
+      <div className="status-panel">
+        <p className="status-panel__loading">Checking services…</p>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="status-panel">
+        <div className="status-check status-check--error">
+          <span className="status-check__dot" />
+          <div className="status-check__body">
+            <span className="status-check__name">API</span>
+            <span className="status-check__msg">Unreachable — {error}</span>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!health) return null
+
+  const entries = Object.entries(health.checks)
+
+  return (
+    <div className="status-panel">
+      <div className={`status-panel__overall status-panel__overall--${health.status}`}>
+        <span className="status-panel__overall-dot" />
+        <span className="status-panel__overall-label">
+          {health.status === 'healthy' ? 'All systems operational' :
+           health.status === 'degraded' ? 'Degraded' : 'Unhealthy'}
+        </span>
+      </div>
+
+      {entries.map(([name, check]) => (
+        <ServiceCheckRow key={name} name={name} check={check} />
+      ))}
+    </div>
+  )
+}
+
+function ServiceCheckRow({ name, check }: { name: string; check: ServiceCheck }) {
+  const displayName = name
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+
+  return (
+    <div className={`status-check status-check--${check.status}`}>
+      <span className="status-check__dot" />
+      <div className="status-check__body">
+        <div className="status-check__header">
+          <span className="status-check__name">{displayName}</span>
+          <span className="status-check__badge">{STATUS_LABEL[check.status] ?? check.status}</span>
+        </div>
+        {check.latency_ms != null && (
+          <span className="status-check__latency">{check.latency_ms.toFixed(0)} ms</span>
+        )}
+        <span className="status-check__msg">{check.message}</span>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Display health check results from /api/health/ in the right sidebar, showing per-service status (Django, Vancouver OpenData, AI Service) with color-coded indicators, latency, and 30s polling.