### PR TITLE
Fix status panel: compact sizing, transparent logo, timezone display

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -65,6 +65,14 @@
   text-align: right;
 }
 
+.insight-shell__tz {
+  font-size: 0.6rem;
+  font-weight: 500;
+  color: var(--data-cyan);
+  opacity: 0.7;
+  letter-spacing: 0.06em;
+}
+
 .insight-shell__body {
   flex: 1;
   min-height: 0;
@@ -266,22 +274,22 @@
 .status-panel {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .status-panel__loading {
   margin: 0;
-  font-size: 0.78rem;
+  font-size: 0.68rem;
   color: var(--text-muted);
 }
 
 .status-panel__overall {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.65rem;
-  border-radius: 5px;
-  margin-bottom: 0.25rem;
+  gap: 0.4rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.15rem;
 }
 
 .status-panel__overall--healthy {
@@ -297,8 +305,8 @@
 }
 
 .status-panel__overall-dot {
-  width: 8px;
-  height: 8px;
+  width: 6px;
+  height: 6px;
   flex-shrink: 0;
   border-radius: 50%;
 }
@@ -319,27 +327,35 @@
 }
 
 .status-panel__overall-label {
-  font-size: 0.78rem;
+  font-size: 0.68rem;
   font-weight: 600;
   color: var(--pacific-slate);
+}
+
+.status-panel__timestamp {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  color: var(--text-dim);
+  text-align: right;
+  opacity: 0.7;
 }
 
 .status-check {
   display: flex;
   align-items: flex-start;
-  gap: 0.55rem;
-  padding: 0.55rem 0.65rem;
-  border-radius: 5px;
+  gap: 0.4rem;
+  padding: 0.4rem 0.5rem;
+  border-radius: 4px;
   border: 1px solid var(--border-subtle);
   background: var(--surface-raised);
 }
 
 .status-check__dot {
-  width: 7px;
-  height: 7px;
+  width: 6px;
+  height: 6px;
   flex-shrink: 0;
   border-radius: 50%;
-  margin-top: 0.25rem;
+  margin-top: 0.22rem;
 }
 
 .status-check--ok .status-check__dot {
@@ -376,18 +392,18 @@
 }
 
 .status-check__name {
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   font-weight: 600;
   color: var(--pacific-slate);
 }
 
 .status-check__badge {
   font-family: var(--font-mono);
-  font-size: 0.55rem;
+  font-size: 0.5rem;
   font-weight: 500;
   letter-spacing: 0.06em;
   text-transform: uppercase;
-  padding: 0.15rem 0.4rem;
+  padding: 0.1rem 0.3rem;
   border-radius: 3px;
   white-space: nowrap;
 }
@@ -414,14 +430,14 @@
 
 .status-check__latency {
   font-family: var(--font-mono);
-  font-size: 0.65rem;
+  font-size: 0.58rem;
   color: var(--text-muted);
 }
 
 .status-check__msg {
-  font-size: 0.7rem;
+  font-size: 0.62rem;
   color: var(--text-dim);
-  line-height: 1.35;
+  line-height: 1.3;
   word-break: break-word;
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -150,7 +150,11 @@ function LiveClock() {
     const t = window.setInterval(() => setNow(new Date()), 1000)
     return () => window.clearInterval(t)
   }, [])
-  return <>{formatClock(now)}</>
+  return (
+    <>
+      {formatClock(now)} <span className="insight-shell__tz">{getTimezone(now)}</span>
+    </>
+  )
 }
 
 function formatClock(d: Date): string {
@@ -163,5 +167,14 @@ function formatClock(d: Date): string {
     }).format(d)
   } catch {
     return d.toLocaleTimeString()
+  }
+}
+
+function getTimezone(d: Date): string {
+  try {
+    const parts = new Intl.DateTimeFormat(undefined, { timeZoneName: 'short' }).formatToParts(d)
+    return parts.find((p) => p.type === 'timeZoneName')?.value ?? ''
+  } catch {
+    return ''
   }
 }

--- a/frontend/src/brand-lockup.css
+++ b/frontend/src/brand-lockup.css
@@ -3,18 +3,20 @@
 .brand-lockup {
   display: inline-flex;
   align-items: center;
-  gap: clamp(0.4rem, 1.5vw, 0.7rem);
+  gap: clamp(0.3rem, 1vw, 0.5rem);
   box-sizing: border-box;
   min-width: 0;
+  background: transparent;
 }
 
 .brand-lockup__icon-wrap {
-  width: clamp(2rem, 4.2vw, 2.625rem);
-  height: clamp(2rem, 4.2vw, 2.625rem);
+  width: clamp(1.4rem, 3vw, 1.75rem);
+  height: clamp(1.4rem, 3vw, 1.75rem);
   flex-shrink: 0;
   display: flex;
   align-items: center;
   justify-content: center;
+  background: transparent;
 }
 
 .brand-lockup__icon-wrap img {
@@ -22,13 +24,14 @@
   height: 100%;
   object-fit: contain;
   display: block;
+  background: transparent;
 }
 
 .brand-lockup__wordmark {
   margin: 0;
   font-family: 'Inter', system-ui, sans-serif;
   font-weight: 800;
-  font-size: clamp(0.62rem, 1.75vw, 0.8125rem);
+  font-size: clamp(0.55rem, 1.4vw, 0.7rem);
   letter-spacing: 0.15em;
   line-height: 1.05;
   color: #002040;
@@ -36,7 +39,7 @@
   white-space: nowrap;
 }
 
-/* Dark surfaces (e.g. app chrome): light wordmark, no white panel */
+/* Dark surfaces (e.g. app chrome): light wordmark */
 .brand-lockup--on-dark .brand-lockup__wordmark {
   color: var(--pacific-slate);
 }

--- a/frontend/src/components/StatusPanel.tsx
+++ b/frontend/src/components/StatusPanel.tsx
@@ -15,10 +15,10 @@ interface HealthResponse {
 }
 
 const STATUS_LABEL: Record<string, string> = {
-  ok: 'Operational',
-  error: 'Error',
-  not_configured: 'Not configured',
-  skipped: 'Skipped',
+  ok: 'OK',
+  error: 'ERR',
+  not_configured: 'N/A',
+  skipped: 'SKIP',
 }
 
 const POLL_INTERVAL_MS = 30_000
@@ -27,16 +27,16 @@ export default function StatusPanel() {
   const [health, setHealth] = useState<HealthResponse | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [lastChecked, setLastChecked] = useState<Date | null>(null)
 
   const fetchHealth = useCallback(async () => {
     try {
       const res = await fetch('/api/health/')
-      if (!res.ok && res.status !== 503) {
-        throw new Error(`HTTP ${res.status}`)
-      }
+      // Always try to parse JSON — backend may return valid health data with 500
       const data: HealthResponse = await res.json()
       setHealth(data)
       setError(null)
+      setLastChecked(new Date())
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to reach API')
       setHealth(null)
@@ -54,7 +54,7 @@ export default function StatusPanel() {
   if (loading) {
     return (
       <div className="status-panel">
-        <p className="status-panel__loading">Checking services…</p>
+        <p className="status-panel__loading">Probing…</p>
       </div>
     )
   }
@@ -82,7 +82,7 @@ export default function StatusPanel() {
       <div className={`status-panel__overall status-panel__overall--${health.status}`}>
         <span className="status-panel__overall-dot" />
         <span className="status-panel__overall-label">
-          {health.status === 'healthy' ? 'All systems operational' :
+          {health.status === 'healthy' ? 'All systems nominal' :
            health.status === 'degraded' ? 'Degraded' : 'Unhealthy'}
         </span>
       </div>
@@ -90,6 +90,12 @@ export default function StatusPanel() {
       {entries.map(([name, check]) => (
         <ServiceCheckRow key={name} name={name} check={check} />
       ))}
+
+      {lastChecked && (
+        <span className="status-panel__timestamp">
+          Last probe {lastChecked.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })}
+        </span>
+      )}
     </div>
   )
 }
@@ -110,7 +116,9 @@ function ServiceCheckRow({ name, check }: { name: string; check: ServiceCheck })
         {check.latency_ms != null && (
           <span className="status-check__latency">{check.latency_ms.toFixed(0)} ms</span>
         )}
-        <span className="status-check__msg">{check.message}</span>
+        {check.message && (
+          <span className="status-check__msg">{check.message}</span>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
- Remove white background from brand lockup, shrink logo for header fit
- Make status panel more compact (smaller fonts, tighter padding)
- Add timezone abbreviation (e.g. PST) to header clock
- Fix HTTP 500 handling: always parse JSON body before treating as error
- Add "last probe" timestamp to status panel